### PR TITLE
fix install script after repo renaming

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,7 @@ install_luajwt() {
     if [ ! -e $lua_dep_dir ]; then
         mkdir -p $lua_dep_dir;
     fi;
-    mv $SOURCE_DIR/haproxy-lua-jwt-master/lib/*.lua $lua_dep_dir 
+    mv $SOURCE_DIR/haproxy-lua-oauth-master/lib/*.lua $lua_dep_dir
 }
 
 install_luajwt_deps() {


### PR DESCRIPTION
A bug is affecting the repo after renaming. To reproduce the bug, just execute the install script. Output:

```
[+] Installing Lua
[+] Downloading haproxy-lua-jwt dependencies
[+] Installing haproxy-lua-jwt dependencies
[+] Downloading haproxy-lua-jwt
[+] Installing haproxy-lua-jwt
mv: cannot stat '/usr/src/haproxy-lua-jwt-master/lib/*.lua': No such file or directory
```

To simply fix the bug, change the line 131 of the install script from:

```
    mv $SOURCE_DIR/haproxy-lua-jwt-master/lib/*.lua $lua_dep_dir
```

to

```
    mv $SOURCE_DIR/haproxy-lua-oauth-master/lib/*.lua $lua_dep_dir
```