### PR TITLE
Add Audience(s) to Variable

### DIFF
--- a/lib/jwtverify.lua
+++ b/lib/jwtverify.lua
@@ -197,14 +197,29 @@ function jwtverify(txn)
     goto out
   end
 
-  -- 7. Add scopes to variable
+  -- 7. Add audience(s) to variable
+  if token.payloaddecoded.aud ~= nil then
+    if type(token.payloaddecoded.aud) == "table" then
+      local audString = " "
+      for key,value in pairs(token.payloaddecoded.aud) do
+        audString=audString..value.." "
+      end
+      txn.set_var(txn, "txn.audience", audString)
+    else
+      txn.set_var(txn, "txn.audience", token.payloaddecoded.aud)
+    end
+  else
+    txn.set_var(txn, "txn.audience", "")
+  end
+
+  -- 8. Add scopes to variable
   if token.payloaddecoded.scope ~= nil then
     txn.set_var(txn, "txn.oauth_scopes", token.payloaddecoded.scope)
   else
     txn.set_var(txn, "txn.oauth_scopes", "")
   end
 
-  -- 8. Set authorized variable
+  -- 9. Set authorized variable
   log("req.authorized = true")
   txn.set_var(txn, "txn.authorized", true)
 


### PR DESCRIPTION
When using HaProxy as an API Gateway it might be required to have differnet Audiences for different backends. This Commit added a Variable called `txn.audience`. This can be used to validate the Audience by an ACL Rule. 

Bsp.:
`http-request deny unless { var(txn.audience) -m sub " audienceA " }`

The leading and trailing whitespaces are there to prevent false flags by the substring method.
Bsp.:
|`http-request deny unless { var(txn.audience) -m sub "audienceA" }`|
|---|
|`audienceA` -> pass|
|`fooaudienceA` -> pass|
|`audienceAbar`-> pass|
|`fooaudienceAbar` -> pass|

|`http-request deny unless { var(txn.audience) -m sub " audienceA " }`|
|---|
|`audienceA` -> pass|
|`fooaudienceA` -> deny|
|`audienceAbar`-> deny|
|`fooaudienceAbar` -> deny|

This change only works when no Audience is set as the Env Variable.